### PR TITLE
fix: remove group metrics when group not exist

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
+++ b/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.exporter.collector;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CounterMetricFamily;
 import io.prometheus.client.GaugeMetricFamily;
+import java.util.Iterator;
 import org.apache.rocketmq.exporter.model.metrics.BrokerMetric;
 import org.apache.rocketmq.exporter.model.metrics.ConsumerMetric;
 import org.apache.rocketmq.exporter.model.metrics.ConsumerQueueMetric;
@@ -172,6 +173,15 @@ public class RMQMetricsCollector extends Collector {
         groupOffset.put(new ConsumerMetric(clusterName,brokerName,topic,group),value);
     }
 
+    public void DelGroupOffsetMetric(String clusterName, String topic, String group) {
+        Iterator<Map.Entry<ConsumerMetric, Double>> it = groupOffset.entrySet().iterator();
+        while(it.hasNext()) {
+            ConsumerMetric m = it.next().getKey();
+            if (m.getClusterName() == clusterName && m.getTopicName() == topic && m.getConsumerGroupName() == group) {
+                it.remove();
+            }
+        }
+    }
 
     public void AddsendBackNumsMetric(String clusterName, String brokerName, String topic, String group,  double value)
     {

--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.exporter.task;
 import com.google.common.base.Throwables;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.admin.ConsumeStats;
 import org.apache.rocketmq.common.admin.OffsetWrapper;
@@ -118,6 +119,10 @@ public class MetricsCollectTask {
                                 } else {
                                     consumeOffsetMap.put(q.getBrokerName(), offset.getConsumerOffset());
                                 }
+                            }
+                        } catch (MQClientException ex) {
+                            if(ex.getResponseCode() == 17) {
+                                metricsService.getCollector().DelGroupOffsetMetric(clusterName, topic, group);
                             }
                         } catch (Exception e) {
                             log.info("ignore this consumer", e.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

remove metrics when group is deleted

## Brief changelog

when get group deleted exception, remove group metrics

## Verifying this change


