### PR TITLE
Change the SendBackNums metric from TPS to a one-minute value

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
+++ b/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
@@ -90,7 +90,7 @@ public class RMQMetricsCollector extends Collector {
     //consumed message size(byte) for consumer-topic
     private ConcurrentHashMap<ConsumerMetric, Double> groupGetSize = new ConcurrentHashMap<>();
     //re-consumed message count for consumer-topic
-    private ConcurrentHashMap<ConsumerMetric, Double> sendBackNums = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<ConsumerMetric, Long> sendBackNums = new ConcurrentHashMap<>();
     // group latency time
     private ConcurrentHashMap<ConsumerMetric, Long> groupLatencyByTime = new ConcurrentHashMap<>();
 
@@ -500,7 +500,7 @@ public class RMQMetricsCollector extends Collector {
         mfs.add(groupGetSizeGauge);
 
         GaugeMetricFamily sendBackNumsGauge = new GaugeMetricFamily("rocketmq_send_back_nums", "SendBackNums", GROUP_NUMS_LABEL_NAMES);
-        for (Map.Entry<ConsumerMetric, Double> entry : sendBackNums.entrySet()) {
+        for (Map.Entry<ConsumerMetric, Long> entry : sendBackNums.entrySet()) {
             loadGroupNumsMetric(sendBackNumsGauge, entry);
         }
         mfs.add(sendBackNumsGauge);
@@ -597,7 +597,7 @@ public class RMQMetricsCollector extends Collector {
         groupGetSize.put(new ConsumerMetric(clusterName, brokerName, topic, group), value);
     }
 
-    public void addSendBackNumsMetric(String clusterName, String brokerName, String topic, String group, double value) {
+    public void addSendBackNumsMetric(String clusterName, String brokerName, String topic, String group, long value) {
         sendBackNums.put(new ConsumerMetric(clusterName, brokerName, topic, group), value);
     }
 

--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -512,7 +512,7 @@ public class MetricsCollectTask {
                                 bd.getBrokerName(),
                                 topic,
                                 group,
-                                Utils.getFixedDouble(bsd.getStatsMinute().getTps()));
+                                bsd.getStatsMinute().getSum());
                         } catch (MQClientException ex) {
                             if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
                                 log.error(String.format("SNDBCK_PUT_NUMS-error, topic=%s, group=%s, master broker=%s, %s", topic, group, masterAddr, ex.getErrorMessage()));


### PR DESCRIPTION
【Background】When sendbacknums indicator is used as the alarm of consumption failure, it is found that the indicator is actually the TPS of sendbacknums, and only two decimal places are reserved. There will be a large error when this indicator is used as the alarm monitoring
【Solution】Using the sum value collected by the index to replace the original TPS value, the online test results are basically consistent with the data collected by the client.
