### PR TITLE
fix: filter group_diff for boardcast

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -295,6 +295,7 @@ public class MetricsCollectTask {
                     log.warn(String.format("no any offset for consumer(%s), topic(%s), ignore this", group, topic));
                     continue;
                 }
+                if (messageModel == MessageModel.CLUSTERING)
                 {
                     diff = consumeStats.computeTotalDiff();
                     consumeTPS = consumeStats.getConsumeTps();


### PR DESCRIPTION
If the consume model is boardcast, the metric group_diff should not collect as consumer's offset stored local。

related issue：
https://github.com/apache/rocketmq-exporter/issues/79