### PR TITLE
[RIP-46] enable exporter to collect and export open-telemetry metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ under the License.
         <rocketmq.version>4.9.4</rocketmq.version>
         <docker.image.prefix>docker.io</docker.image.prefix>
         <opentelemetry-proto.version>0.18.0-alpha</opentelemetry-proto.version>
-        <prometheus.verion>0.15.0</prometheus.verion>
+        <prometheus.version>0.15.0</prometheus.version>
         <distMgmtReleasesName>Apache Release Distribution Repository</distMgmtReleasesName>
         <distMgmtReleasesUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtReleasesUrl>
         <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.apache</groupId>
     <artifactId>rocketmq-exporter</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <name>rocketmq-exporter</name>
 
     <description>Apache RocketMQ Prometheus Exporter</description>
@@ -18,13 +18,14 @@
     <properties>
         <rocketmq.version>4.8.0</rocketmq.version>
         <docker.image.prefix>docker.io</docker.image.prefix>
+        <opentelemetry-proto.version>0.18.0-alpha</opentelemetry-proto.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -48,7 +49,22 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.6.0</version>
+            <version>0.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry-proto.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
+            <version>1.45.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>1.45.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/apache/rocketmq/exporter/RocketMQExporterApplication.java
+++ b/src/main/java/org/apache/rocketmq/exporter/RocketMQExporterApplication.java
@@ -32,7 +32,8 @@ public class RocketMQExporterApplication implements CommandLineRunner {
         SpringApplication.run(RocketMQExporterApplication.class, args);
     }
 
-    @Override public void run(String... args) throws Exception {
+    @Override
+    public void run(String... args) throws Exception {
         return;
     }
 }

--- a/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
+++ b/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
@@ -37,6 +37,7 @@ import org.apache.rocketmq.exporter.model.metrics.clientrunime.ConsumerRuntimeCo
 import org.apache.rocketmq.exporter.model.metrics.clientrunime.ConsumerRuntimeConsumeRTMetric;
 import org.apache.rocketmq.exporter.model.metrics.clientrunime.ConsumerRuntimePullRTMetric;
 import org.apache.rocketmq.exporter.model.metrics.clientrunime.ConsumerRuntimePullTPSMetric;
+import org.apache.rocketmq.exporter.otlp.OtlpMetricsCollectorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -363,6 +364,14 @@ public class RMQMetricsCollector extends Collector {
 
     }
 
+    private OtlpMetricsCollectorService otlpMetricsCollectorService;
+
+    public void setOtlpMetricsCollectorService(
+        OtlpMetricsCollectorService otlpMetricsCollectorService) {
+        log.info("init RMQMetricsService add opentelemetry collector...");
+        this.otlpMetricsCollectorService = otlpMetricsCollectorService;
+    }
+
     @Override
     public List<MetricFamilySamples> collect() {
 
@@ -381,6 +390,9 @@ public class RMQMetricsCollector extends Collector {
         collectBrokerNums(mfs);
 
         collectBrokerRuntimeStats(mfs);
+
+        // v2 opentelemetry metrics
+        otlpMetricsCollectorService.collectOtlpMetrics(mfs);
 
         return mfs;
     }

--- a/src/main/java/org/apache/rocketmq/exporter/otlp/OtlpGrpcLauncher.java
+++ b/src/main/java/org/apache/rocketmq/exporter/otlp/OtlpGrpcLauncher.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.otlp;
+
+import javax.annotation.PostConstruct;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OtlpGrpcLauncher {
+
+    private Logger log = LoggerFactory.getLogger(OtlpGrpcLauncher.class);
+
+    private Server server;
+
+    @Value("${grpc.server.port}")
+    private Integer grpcServerPort;
+
+    @Autowired
+    OtlpMetricsCollectorService otlpMetricsCollectorService;
+
+    @PostConstruct
+    public void start() throws Exception {
+        try {
+            server = ServerBuilder.forPort(grpcServerPort)
+                .addService(otlpMetricsCollectorService)
+                .build().start();
+            log.info("grpc server start successfully at " + grpcServerPort);
+            Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+        } catch (Exception e) {
+            log.error("grpc server start failed.", e);
+            throw e;
+        }
+    }
+
+    private void stop() {
+        if (server != null) {
+            server.shutdownNow();
+            log.info("grpc server shutdown successfully.");
+        }
+    }
+
+}

--- a/src/main/java/org/apache/rocketmq/exporter/otlp/OtlpMetricsCollectorService.java
+++ b/src/main/java/org/apache/rocketmq/exporter/otlp/OtlpMetricsCollectorService.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.otlp;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OtlpMetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase  {
+
+    private final List<MetricFamilySamples> otlpMfs = new ArrayList<>();
+
+    private final static Logger log = LoggerFactory.getLogger(OtlpMetricsCollectorService.class);
+
+    @Override
+    public void export(ExportMetricsServiceRequest request,
+        StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+        log.info("receive oltp metrics export request...");
+        try {
+            List<MetricFamilySamples> newMfs = new ArrayList<>();
+            collectMetrics(request, newMfs);
+            synchronized (otlpMfs) {
+                otlpMfs.clear();
+                otlpMfs.addAll(newMfs);
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error when exporting otlp metrics, request={}", request, e);
+            responseObserver.onError(e);
+        }
+        //responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    public void collectOtlpMetrics(List<MetricFamilySamples> mfs) {
+        synchronized (otlpMfs) {
+            mfs.addAll(otlpMfs);
+        }
+    }
+
+    private void collectMetrics(ExportMetricsServiceRequest request, List<MetricFamilySamples> mfs) {
+        final List<ResourceMetrics> resourceMetricsList = request.getResourceMetricsList();
+        for (ResourceMetrics resourceMetrics : resourceMetricsList) {
+            final List<ScopeMetrics> scopeMetricsList = resourceMetrics.getScopeMetricsList();
+            for (ScopeMetrics scopeMetrics : scopeMetricsList) {
+                final List<Metric> metricList = scopeMetrics.getMetricsList();
+                for (Metric metric : metricList) {
+                    String name = metric.getName();
+                    switch (metric.getDataCase()) {
+                        case GAUGE: {
+                            final List<NumberDataPoint> pointList = metric.getGauge().getDataPointsList();
+                            final List<KeyValue> attributesList = pointList.get(0).getAttributesList();
+                            List<String> labelNames = attributesList.stream()
+                                .sorted(Comparator.comparing(KeyValue::getKey))
+                                .map(KeyValue::getKey)
+                                .collect(Collectors.toList());
+                            GaugeMetricFamily metricFamily = new GaugeMetricFamily(name, name, labelNames);
+                            for (NumberDataPoint point : pointList) {
+                                loadGaugeMetric(metricFamily, point);
+                            }
+                            mfs.add(metricFamily);
+                            break;
+                        }
+                        case SUM: {
+                            final List<NumberDataPoint> pointList = metric.getSum().getDataPointsList();
+                            final List<KeyValue> attributesList = pointList.get(0).getAttributesList();
+                            List<String> labelNames = attributesList.stream()
+                                .sorted(Comparator.comparing(KeyValue::getKey))
+                                .map(KeyValue::getKey)
+                                .collect(Collectors.toList());
+                            CounterMetricFamily metricFamily = new CounterMetricFamily(name, name, labelNames);
+                            for (NumberDataPoint point : pointList) {
+                                loadCounterMetric(metricFamily, point);
+                            }
+                            mfs.add(metricFamily);
+                            break;
+                        }
+                        case HISTOGRAM: {
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
+    private void loadGaugeMetric(GaugeMetricFamily family, NumberDataPoint point) {
+        final List<KeyValue> attributesList = point.getAttributesList();
+        List<String> labelValues = attributesList.stream()
+            .sorted(Comparator.comparing(KeyValue::getKey))
+            .map(KeyValue::getValue)
+            .map(AnyValue::getStringValue)
+            .collect(Collectors.toList());
+        family.addMetric(labelValues, point.getAsDouble());
+    }
+
+    private void loadCounterMetric(CounterMetricFamily family, NumberDataPoint point) {
+        final List<KeyValue> attributesList = point.getAttributesList();
+        List<String> labelValues = attributesList.stream()
+            .sorted(Comparator.comparing(KeyValue::getKey))
+            .map(KeyValue::getValue)
+            .map(AnyValue::getStringValue)
+            .collect(Collectors.toList());
+        family.addMetric(labelValues, point.getAsDouble());
+    }
+}

--- a/src/main/java/org/apache/rocketmq/exporter/service/impl/RMQMetricsServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/exporter/service/impl/RMQMetricsServiceImpl.java
@@ -20,6 +20,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.apache.rocketmq.exporter.collector.RMQMetricsCollector;
 import org.apache.rocketmq.exporter.config.RMQConfigure;
+import org.apache.rocketmq.exporter.otlp.OtlpMetricsCollectorService;
 import org.apache.rocketmq.exporter.service.RMQMetricsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,10 @@ public class RMQMetricsServiceImpl implements RMQMetricsService {
     private CollectorRegistry registry = new CollectorRegistry();
     private final RMQMetricsCollector rmqMetricsCollector;
 
+    @Autowired
+    private OtlpMetricsCollectorService otlpMetricsCollectorService;
+
+    @Override
     public RMQMetricsCollector getCollector() {
         return rmqMetricsCollector;
     }
@@ -47,8 +52,10 @@ public class RMQMetricsServiceImpl implements RMQMetricsService {
         this.configure = configure;
         rmqMetricsCollector = new RMQMetricsCollector(configure.getOutOfTimeSeconds());
         rmqMetricsCollector.register(registry);
+        rmqMetricsCollector.setOtlpMetricsCollectorService(otlpMetricsCollectorService);
     }
 
+    @Override
     public void metrics(StringWriter writer) throws IOException {
         this.writeEscapedHelp(writer, registry.metricFamilySamples());
     }

--- a/src/main/java/org/apache/rocketmq/exporter/service/impl/RMQMetricsServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/exporter/service/impl/RMQMetricsServiceImpl.java
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.util.Enumeration;
 import java.util.Iterator;
 
+import javax.annotation.PostConstruct;
 
 @Service
 public class RMQMetricsServiceImpl implements RMQMetricsService {
@@ -52,6 +53,10 @@ public class RMQMetricsServiceImpl implements RMQMetricsService {
         this.configure = configure;
         rmqMetricsCollector = new RMQMetricsCollector(configure.getOutOfTimeSeconds());
         rmqMetricsCollector.register(registry);
+    }
+
+    @PostConstruct
+    public void init() {
         rmqMetricsCollector.setOtlpMetricsCollectorService(otlpMetricsCollectorService);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,10 @@ rocketmq:
     secretKey:  # if >=4.4.0
     outOfTimeSeconds: 60 # Cache clear time with no update
 
+grpc:
+  server:
+    port: 5559
+
 threadpool:
   collect-client-metric-executor:
     core-pool-size: 10


### PR DESCRIPTION
This is part of implementation of [RIP-46](https://github.com/apache/rocketmq/wiki/RIP-46-Observability-improvement-for-RocketMQ)

Since [#5355](https://github.com/apache/rocketmq/pull/5355), a new version of broker metrics based on open-telemetry standard has been introduced into rocketmq broker. Different form the previous version, the new metrics are produced by broker, proxy or client, not by exporter.

Some users are now using rocketmq-exporter. New metrics require compatibility with current usage. And the control panel, such as Prometheus, is not necessarily deployed under the same network as broker. So It is also meaningful to design a proxy mode of rocketmq-exporter to access new metrics data.

We could implement an OpenTelemetry collector in rocketmq-exporter: Broker export metrics data to rocketmq-exporter, and rocketmq-exporter provide a new endpoint for Prometheus access.

![image](https://user-images.githubusercontent.com/23614576/213078853-ed5372e5-2b63-4c0f-b4e1-2202ce61447f.png)

You should start the broker with the following config.
```
metricsExporterType = 1
metricsGrpcExporterTarget = http://127.0.0.1:5559
metricGrpcExporterIntervalInMills = 10000
```

After the exporter starts, the following log means the open-telemetry metrics has been collected.
![image](https://user-images.githubusercontent.com/23614576/213399129-ff276941-317c-4645-a0cc-b0e9ac463226.png)
