### PR TITLE
[ISSUE #144]enhance: Asynchronous collect topic status metrics

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/config/CollectClientMetricExecutorConfig.java
+++ b/src/main/java/org/apache/rocketmq/exporter/config/CollectClientMetricExecutorConfig.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "threadpool.collect-client-metric-executor")
+@ConfigurationProperties(prefix = "thread-pool.collect-client-metric-executor")
 public class CollectClientMetricExecutorConfig {
     private int corePoolSize = 20;
     private int maximumPoolSize = 20;

--- a/src/main/java/org/apache/rocketmq/exporter/config/CollectTopicMetricExecutorConfig.java
+++ b/src/main/java/org/apache/rocketmq/exporter/config/CollectTopicMetricExecutorConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.config;
+
+import org.apache.rocketmq.exporter.task.TopicMetricCollectorFixedThreadPoolExecutor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Configuration
+@ConfigurationProperties(prefix = "thread-pool.collect-topic-metric-executor")
+public class CollectTopicMetricExecutorConfig {
+    private int corePoolSize = 20;
+    private int maximumPoolSize = 20;
+    private long keepAliveTime = 4000L;
+    private int queueSize = 1000;
+
+    @Bean(name = "collectTopicMetricExecutor")
+    public ExecutorService collectTopicMetricExecutor() {
+        BlockingQueue<Runnable> collectTopicMetricTaskBlockQueue = new LinkedBlockingDeque<Runnable>(queueSize);
+        return new TopicMetricCollectorFixedThreadPoolExecutor(
+            corePoolSize,
+            maximumPoolSize,
+            keepAliveTime,
+            TimeUnit.MILLISECONDS,
+            collectTopicMetricTaskBlockQueue,
+            new ThreadFactory() {
+                private final AtomicLong threadIndex = new AtomicLong(0);
+
+                @Override
+                public Thread newThread(Runnable r) {
+                    return new Thread(r, "topicMetricThread_" + this.threadIndex.incrementAndGet());
+                }
+            },
+            new ThreadPoolExecutor.DiscardOldestPolicy()
+        );
+    }
+}

--- a/src/main/java/org/apache/rocketmq/exporter/task/BrokerTopicStatsMetricTaskRunnable.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/BrokerTopicStatsMetricTaskRunnable.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.task;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.protocol.ResponseCode;
+import org.apache.rocketmq.common.protocol.body.BrokerStatsData;
+import org.apache.rocketmq.common.protocol.body.ClusterInfo;
+import org.apache.rocketmq.common.protocol.body.GroupList;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.apache.rocketmq.common.topic.TopicValidator;
+import org.apache.rocketmq.exporter.service.RMQMetricsService;
+import org.apache.rocketmq.exporter.util.Utils;
+import org.apache.rocketmq.remoting.exception.RemotingConnectException;
+import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
+import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.slf4j.Logger;
+
+public class BrokerTopicStatsMetricTaskRunnable implements Runnable {
+
+    private final Logger log;
+    private final String  topic;
+    private final ClusterInfo clusterInfo;
+    private final MQAdminExt mqAdminExt;
+    private final TopicRouteData topicRouteData;
+    private final RMQMetricsService metricsService;
+
+
+    public BrokerTopicStatsMetricTaskRunnable(
+        Logger log,
+        String topic,
+        ClusterInfo clusterInfo,
+        MQAdminExt mqAdminExt,
+        TopicRouteData topicRouteData,
+        RMQMetricsService metricsService) {
+        this.log = log;
+        this.topic = topic;
+        this.clusterInfo = clusterInfo;
+        this.mqAdminExt = mqAdminExt;
+        this.topicRouteData = topicRouteData;
+        this.metricsService = metricsService;
+    }
+
+
+    @Override
+    public void run() {
+        collectProducerStats();
+        collectConsumerGroupStats();
+    }
+
+    private void collectProducerStats() {
+        for (BrokerData bd : topicRouteData.getBrokerDatas()) {
+            String masterAddr = bd.getBrokerAddrs().get(MixAll.MASTER_ID);
+            if (!StringUtils.isBlank(masterAddr)) {
+                BrokerStatsData bsd = null;
+                try {
+                    //how many messages has sent for the topic
+                    bsd = mqAdminExt.viewBrokerStatsData(masterAddr, BrokerStatsManager.TOPIC_PUT_NUMS, topic);
+                    String brokerIP = clusterInfo.getBrokerAddrTable().get(bd.getBrokerName()).getBrokerAddrs().get(MixAll.MASTER_ID);
+                    metricsService.getCollector().addTopicPutNumsMetric(
+                        bd.getCluster(),
+                        bd.getBrokerName(),
+                        brokerIP,
+                        topic,
+                        Utils.getFixedDouble(bsd.getStatsMinute().getSum())
+                    );
+                } catch (MQClientException ex) {
+                    if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
+                        //log.error(String.format("TOPIC_PUT_NUMS-error, topic=%s, master broker=%s, %s", topic, masterAddr, ex.getErrorMessage()));
+                    } else {
+                        log.error(String.format("TOPIC_PUT_NUMS-error, topic=%s, master broker=%s", topic, masterAddr), ex);
+                    }
+                } catch (RemotingTimeoutException | InterruptedException | RemotingSendRequestException | RemotingConnectException ex1) {
+                    log.error(String.format("TOPIC_PUT_NUMS-error, topic=%s, master broker=%s", topic, masterAddr), ex1);
+                }
+                try {
+                    //how many bytes has sent for the topic
+                    bsd = mqAdminExt.viewBrokerStatsData(masterAddr, BrokerStatsManager.TOPIC_PUT_SIZE, topic);
+                    String brokerIP = clusterInfo.getBrokerAddrTable().get(bd.getBrokerName()).getBrokerAddrs().get(MixAll.MASTER_ID);
+                    metricsService.getCollector().addTopicPutSizeMetric(
+                        bd.getCluster(),
+                        bd.getBrokerName(),
+                        brokerIP,
+                        topic,
+                        Utils.getFixedDouble(bsd.getStatsMinute().getSum())
+                    );
+                } catch (MQClientException ex) {
+                    if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
+                        //log.error(String.format("TOPIC_PUT_SIZE-error, topic=%s, master broker=%s, %s", topic, masterAddr, ex.getErrorMessage()));
+                    } else {
+                        log.error(String.format("TOPIC_PUT_SIZE-error, topic=%s, master broker=%s", topic, masterAddr), ex);
+                    }
+                } catch (InterruptedException | RemotingConnectException | RemotingTimeoutException | RemotingSendRequestException ex) {
+                    log.error(String.format("TOPIC_PUT_SIZE-error, topic=%s, master broker=%s", topic, masterAddr), ex);
+                }
+            }
+        }
+
+        GroupList groupList = null;
+        try {
+            groupList = mqAdminExt.queryTopicConsumeByWho(topic);
+        } catch (Exception ex) {
+            //log.error(String.format("collectBrokerStatsTopic-fetch consumers for topic(%s) error, ignore this topic", topic), ex);
+        }
+        if (groupList.getGroupList() == null || groupList.getGroupList().isEmpty()) {
+            //log.warn(String.format("collectBrokerStatsTopic-topic's consumer is empty, %s", topic));
+        }
+    }
+
+    private void collectConsumerGroupStats() {
+        GroupList groupList = null;
+        try {
+            groupList = mqAdminExt.queryTopicConsumeByWho(topic);
+        } catch (Exception ex) {
+            //log.error(String.format("collectBrokerStatsTopic-fetch consumers for topic(%s) error, ignore this topic", topic), ex);
+            return;
+        }
+
+        if (TopicValidator.RMQ_SYS_SCHEDULE_TOPIC.equals(topic)) {
+            groupList.getGroupList().add(MixAll.SCHEDULE_CONSUMER_GROUP);
+        }
+
+        if (groupList.getGroupList() == null || groupList.getGroupList().isEmpty()) {
+            //log.warn(String.format("collectBrokerStatsTopic-topic's consumer is empty, %s", topic));
+            return;
+        }
+        for (String group : groupList.getGroupList()) {
+            for (BrokerData bd : topicRouteData.getBrokerDatas()) {
+                String masterAddr = bd.getBrokerAddrs().get(MixAll.MASTER_ID);
+                if (masterAddr != null) {
+                    String statsKey = String.format("%s@%s", topic, group);
+                    BrokerStatsData bsd = null;
+                    try {
+                        //how many messages the consumer has get for the topic
+                        bsd = mqAdminExt.viewBrokerStatsData(masterAddr, BrokerStatsManager.GROUP_GET_NUMS, statsKey);
+                        metricsService.getCollector().addGroupGetNumsMetric(
+                            bd.getCluster(),
+                            bd.getBrokerName(),
+                            topic,
+                            group,
+                            Utils.getFixedDouble(bsd.getStatsMinute().getTps()));
+                    } catch (MQClientException ex) {
+                        if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
+                            //log.error(String.format("GROUP_GET_NUMS-error, topic=%s, group=%s,master broker=%s, %s", topic, group, masterAddr, ex.getErrorMessage()));
+                        } else {
+                            log.error(String.format("GROUP_GET_NUMS-error, topic=%s, group=%s,master broker=%s", topic, group, masterAddr), ex);
+                        }
+                    } catch (InterruptedException | RemotingConnectException | RemotingTimeoutException | RemotingSendRequestException ex) {
+                        log.error(String.format("GROUP_GET_NUMS-error, topic=%s, group=%s,master broker=%s", topic, group, masterAddr), ex);
+                    }
+                    try {
+                        //how many bytes the consumer has get for the topic
+                        bsd = mqAdminExt.viewBrokerStatsData(masterAddr, BrokerStatsManager.GROUP_GET_SIZE, statsKey);
+                        metricsService.getCollector().addGroupGetSizeMetric(
+                            bd.getCluster(),
+                            bd.getBrokerName(),
+                            topic,
+                            group,
+                            Utils.getFixedDouble(bsd.getStatsMinute().getTps()));
+                    } catch (MQClientException ex) {
+                        if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
+                            // log.error(String.format("GROUP_GET_SIZE-error, topic=%s, group=%s, master broker=%s, %s", topic, group, masterAddr, ex.getErrorMessage()));
+                        } else {
+                            log.error(String.format("GROUP_GET_SIZE-error, topic=%s, group=%s, master broker=%s", topic, group, masterAddr), ex);
+                        }
+                    } catch (InterruptedException | RemotingConnectException | RemotingTimeoutException | RemotingSendRequestException ex) {
+                        log.error(String.format("GROUP_GET_SIZE-error, topic=%s, group=%s, master broker=%s", topic, group, masterAddr), ex);
+                    }
+                    try {
+                        ////how many re-send times the consumer did for the topic
+                        bsd = mqAdminExt.viewBrokerStatsData(masterAddr, BrokerStatsManager.SNDBCK_PUT_NUMS, statsKey);
+                        metricsService.getCollector().addSendBackNumsMetric(
+                            bd.getCluster(),
+                            bd.getBrokerName(),
+                            topic,
+                            group,
+                            bsd.getStatsMinute().getSum());
+                    } catch (MQClientException ex) {
+                        if (ex.getResponseCode() == ResponseCode.SYSTEM_ERROR) {
+                            //log.error(String.format("SNDBCK_PUT_NUMS-error, topic=%s, group=%s, master broker=%s, %s", topic, group, masterAddr, ex.getErrorMessage()));
+                        } else {
+                            log.error(String.format("SNDBCK_PUT_NUMS-error, topic=%s, group=%s, master broker=%s", topic, group, masterAddr), ex);
+                        }
+                    } catch (InterruptedException | RemotingConnectException | RemotingTimeoutException | RemotingSendRequestException ex) {
+                        log.error(String.format("SNDBCK_PUT_NUMS-error, topic=%s, group=%s, master broker=%s", topic, group, masterAddr), ex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/rocketmq/exporter/task/TopicMetricCollectorFixedThreadPoolExecutor.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/TopicMetricCollectorFixedThreadPoolExecutor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.task;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class TopicMetricCollectorFixedThreadPoolExecutor extends ThreadPoolExecutor {
+    public TopicMetricCollectorFixedThreadPoolExecutor(int corePoolSize, int maximumPoolSize,
+                                                       long keepAliveTime, TimeUnit unit,
+                                                       BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory,
+                                                       RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+        return new FutureTask(runnable, value);
+    }
+}

--- a/src/main/java/org/apache/rocketmq/exporter/task/TopicOffsetMetricTaskRunnable.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/TopicOffsetMetricTaskRunnable.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.task;
+
+import com.alibaba.fastjson.JSON;
+import org.apache.rocketmq.common.admin.TopicOffset;
+import org.apache.rocketmq.common.admin.TopicStatsTable;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.exporter.service.RMQMetricsService;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class TopicOffsetMetricTaskRunnable implements Runnable {
+    private final Logger log;
+    private final MQAdminExt mqAdminExt;
+    private final String topic;
+    private final String clusterName;
+    private final RMQMetricsService metricsService;
+
+
+    public TopicOffsetMetricTaskRunnable(
+        Logger log,
+        MQAdminExt mqAdminExt,
+        String topic,
+        String clusterName,
+        RMQMetricsService metricsService) {
+        this.log = log;
+        this.mqAdminExt = mqAdminExt;
+        this.topic = topic;
+        this.clusterName = clusterName;
+        this.metricsService = metricsService;
+    }
+
+    @Override
+    public void run() {
+        TopicStatsTable topicStats = null;
+        try {
+            topicStats = mqAdminExt.examineTopicStats(topic);
+        } catch (Exception ex) {
+            log.error(String.format("collectTopicOffset-getting topic(%s) stats error. the namesrv address is %s",
+                topic,
+                JSON.toJSONString(mqAdminExt.getNameServerAddressList())));
+            return;
+        }
+
+        Set<Map.Entry<MessageQueue, TopicOffset>> topicStatusEntries = topicStats.getOffsetTable().entrySet();
+        HashMap<String, Long> brokerOffsetMap = new HashMap<>();
+        HashMap<String, Long> brokerUpdateTimestampMap = new HashMap<>();
+
+        for (Map.Entry<MessageQueue, TopicOffset> topicStatusEntry : topicStatusEntries) {
+            MessageQueue q = topicStatusEntry.getKey();
+            TopicOffset offset = topicStatusEntry.getValue();
+
+            if (brokerOffsetMap.containsKey(q.getBrokerName())) {
+                brokerOffsetMap.put(q.getBrokerName(), brokerOffsetMap.get(q.getBrokerName()) + offset.getMaxOffset());
+            } else {
+                brokerOffsetMap.put(q.getBrokerName(), offset.getMaxOffset());
+            }
+
+            if (brokerUpdateTimestampMap.containsKey(q.getBrokerName())) {
+                if (offset.getLastUpdateTimestamp() > brokerUpdateTimestampMap.get(q.getBrokerName())) {
+                    brokerUpdateTimestampMap.put(q.getBrokerName(), offset.getLastUpdateTimestamp());
+                }
+            } else {
+                brokerUpdateTimestampMap.put(q.getBrokerName(), offset.getLastUpdateTimestamp());
+            }
+        }
+        Set<Map.Entry<String, Long>> brokerOffsetEntries = brokerOffsetMap.entrySet();
+        for (Map.Entry<String, Long> brokerOffsetEntry : brokerOffsetEntries) {
+            metricsService.getCollector().addTopicOffsetMetric(clusterName, brokerOffsetEntry.getKey(), topic,
+                brokerUpdateTimestampMap.get(brokerOffsetEntry.getKey()), brokerOffsetEntry.getValue());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,12 +24,18 @@ rocketmq:
     secretKey:  # if >=4.4.0
     outOfTimeSeconds: 60 # Cache clear time with no update
 
-threadpool:
+thread-pool:
   collect-client-metric-executor:
     core-pool-size: 10
     maximum-pool-size: 10
     keep-alive-time: 3000
     queueSize: 5000
+  collect-topic-metric-executor:
+    core-poll-size: 10
+    maximum-pool-size: 10
+    keep-alive-time: 3000
+    queueSize: 5000
+
 task:
   count: 5 # num of scheduled-tasks
   collectTopicOffset:


### PR DESCRIPTION
## What is the purpose of the change

Use executor to generate topic stats metrics to avoid the discontinuous metric line, caused by metrics can not be collect in valid time（1 minute）
closes #144 

## Brief changelog

Use executor to replace single thread.

## Verifying this change
![image](https://github.com/apache/rocketmq-exporter/assets/50660789/306a2b88-fa58-4f90-8604-e0b5fb2d06e3)

