### PR TITLE
fix the metric collection bug

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -268,6 +268,7 @@ public class MetricsCollectTask {
         }
 
         Set<String> topicSet = topicList.getTopicList();
+        Set<String> groupCollected = new HashSet<String>();
         for (String topic : topicSet) {
             GroupList groupList = null;
 
@@ -322,7 +323,7 @@ public class MetricsCollectTask {
                     }
                     metricsService.getCollector().addGroupCountMetric(group, cAddrs, localAddrs, countOfOnlineConsumers);
                 }
-                if (countOfOnlineConsumers > 0) {
+                if (countOfOnlineConsumers > 0 && !groupCollected.contains(group)) {
                     collectClientMetricExecutor.submit(new ClientMetricTaskRunnable(
                         group,
                         onlineConsumers,
@@ -331,6 +332,7 @@ public class MetricsCollectTask {
                         log,
                         this.metricsService
                     ));
+                    groupCollected.add(group);
                 }
                 try {
                     consumeStats = mqAdminExt.examineConsumeStats(group, topic);


### PR DESCRIPTION
redundant queries can lead to server bandwidth being saturated. The detailed content is as follows, Two broker nodes, one exporter node, one consumer subscribing to 1000 topics, with 20 consumers in total. The traffic on the broker nodes is 75MB/s, while the exporter node handles approximately 150MB/s of continuous traffic.

## What is the purpose of the change

fix the metric collection bug, eliminate redundant queries.

## Brief changelog

redundant queries can lead to server bandwidth being saturated, avoid duplicate execution of  collectClientMetricExecutor.submit().

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
