### PR TITLE
[ISSUE #190] Support queue-level consumer metrics behind a topic whitelist

### DIFF
--- a/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
+++ b/src/main/java/org/apache/rocketmq/exporter/collector/RMQMetricsCollector.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.exporter.model.BrokerRuntimeStats;
 import org.apache.rocketmq.exporter.model.metrics.BrokerMetric;
 import org.apache.rocketmq.exporter.model.metrics.ConsumerCountMetric;
 import org.apache.rocketmq.exporter.model.metrics.ConsumerMetric;
+import org.apache.rocketmq.exporter.model.metrics.ConsumerQueueMetric;
 import org.apache.rocketmq.exporter.model.metrics.ConsumerTopicDiffMetric;
 import org.apache.rocketmq.exporter.model.metrics.DLQTopicOffsetMetric;
 import org.apache.rocketmq.exporter.model.metrics.TopicPutNumMetric;
@@ -98,6 +99,13 @@ public class RMQMetricsCollector extends Collector {
     private Cache<ConsumerMetric, Double> sendBackNums;
     // group latency time
     private Cache<ConsumerMetric, Long> groupLatencyByTime;
+
+    //queue-level diff for consumer group, only collected for topics enabled by rocketmq.config.queueLevelTopics
+    private Cache<ConsumerQueueMetric, Long> queueGroupDiff;
+    //queue-level consumer offset, only collected for topics enabled by rocketmq.config.queueLevelTopics
+    private Cache<ConsumerQueueMetric, Long> queueConsumerOffset;
+    //queue-level latency time, only collected for topics enabled by rocketmq.config.queueLevelTopics
+    private Cache<ConsumerQueueMetric, Long> queueLatencyByTime;
 
     //total put message count for one broker
     private Cache<BrokerMetric, Double> brokerPutNums;
@@ -203,6 +211,9 @@ public class RMQMetricsCollector extends Collector {
         this.groupGetSize = initCache(outOfTimeSeconds);
         this.sendBackNums = initCache(outOfTimeSeconds);
         this.groupLatencyByTime = initCache(outOfTimeSeconds);
+        this.queueGroupDiff = initCache(outOfTimeSeconds);
+        this.queueConsumerOffset = initCache(outOfTimeSeconds);
+        this.queueLatencyByTime = initCache(outOfTimeSeconds);
         this.brokerPutNums = initCache(outOfTimeSeconds);
         this.brokerGetNums = initCache(outOfTimeSeconds);
         this.brokerCommitLogDiff = initCache(outOfTimeSeconds);
@@ -411,6 +422,8 @@ public class RMQMetricsCollector extends Collector {
         collectTopicNums(mfs);
 
         collectGroupNums(mfs);
+
+        collectQueueGroupNums(mfs);
 
         collectClientGroupMetric(mfs);
 
@@ -655,6 +668,45 @@ public class RMQMetricsCollector extends Collector {
 
     }
 
+    private static final List<String> QUEUE_GROUP_NUMS_LABEL_NAMES = Arrays.asList(
+        "cluster", "broker", "topic", "group", "queueid"
+    );
+
+    private static <T extends Number> void loadQueueGroupNumsMetric(GaugeMetricFamily family,
+        Map.Entry<ConsumerQueueMetric, T> entry) {
+        family.addMetric(Arrays.asList(
+            entry.getKey().getClusterName(),
+            entry.getKey().getBrokerName(),
+            entry.getKey().getTopicName(),
+            entry.getKey().getConsumerGroupName(),
+            entry.getKey().getQueueId()),
+            entry.getValue().doubleValue()
+        );
+    }
+
+    private void collectQueueGroupNums(List<MetricFamilySamples> mfs) {
+        GaugeMetricFamily queueGroupDiffF = new GaugeMetricFamily("rocketmq_queue_group_diff",
+            "QueueGroupDiff", QUEUE_GROUP_NUMS_LABEL_NAMES);
+        for (Map.Entry<ConsumerQueueMetric, Long> entry : queueGroupDiff.asMap().entrySet()) {
+            loadQueueGroupNumsMetric(queueGroupDiffF, entry);
+        }
+        mfs.add(queueGroupDiffF);
+
+        GaugeMetricFamily queueConsumerOffsetF = new GaugeMetricFamily("rocketmq_queue_consumer_offset",
+            "QueueConsumerOffset", QUEUE_GROUP_NUMS_LABEL_NAMES);
+        for (Map.Entry<ConsumerQueueMetric, Long> entry : queueConsumerOffset.asMap().entrySet()) {
+            loadQueueGroupNumsMetric(queueConsumerOffsetF, entry);
+        }
+        mfs.add(queueConsumerOffsetF);
+
+        GaugeMetricFamily queueLatencyByTimeF = new GaugeMetricFamily("rocketmq_queue_group_get_latency_by_storetime",
+            "QueueGroupGetLatencyByStoreTime", QUEUE_GROUP_NUMS_LABEL_NAMES);
+        for (Map.Entry<ConsumerQueueMetric, Long> entry : queueLatencyByTime.asMap().entrySet()) {
+            loadQueueGroupNumsMetric(queueLatencyByTimeF, entry);
+        }
+        mfs.add(queueLatencyByTimeF);
+    }
+
     private void collectTopicNums(List<MetricFamilySamples> mfs) {
         GaugeMetricFamily topicPutNumsGauge = new GaugeMetricFamily("rocketmq_producer_tps", "TopicPutNums", TOPIC_NUMS_LABEL_NAMES);
         for (Map.Entry<TopicPutNumMetric, Double> entry : topicPutNums.asMap().entrySet()) {
@@ -724,6 +776,21 @@ public class RMQMetricsCollector extends Collector {
 
     public void addGroupGetLatencyByStoreTimeMetric(String clusterName, String brokerName, String topic, String group, long value) {
         groupLatencyByTime.put(new ConsumerMetric(clusterName, brokerName, topic, group), value);
+    }
+
+    public void addQueueGroupDiffMetric(String clusterName, String brokerName, String topic, String group,
+        String queueId, long value) {
+        queueGroupDiff.put(new ConsumerQueueMetric(clusterName, brokerName, topic, group, queueId), value);
+    }
+
+    public void addQueueConsumerOffsetMetric(String clusterName, String brokerName, String topic, String group,
+        String queueId, long value) {
+        queueConsumerOffset.put(new ConsumerQueueMetric(clusterName, brokerName, topic, group, queueId), value);
+    }
+
+    public void addQueueGroupGetLatencyByStoreTimeMetric(String clusterName, String brokerName, String topic,
+        String group, String queueId, long value) {
+        queueLatencyByTime.put(new ConsumerQueueMetric(clusterName, brokerName, topic, group, queueId), value);
     }
 
     public void addGroupConsumerTotalOffsetMetric(String topic, String group, long value) {

--- a/src/main/java/org/apache/rocketmq/exporter/config/RMQConfigure.java
+++ b/src/main/java/org/apache/rocketmq/exporter/config/RMQConfigure.java
@@ -23,6 +23,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.apache.rocketmq.client.ClientConfig.SEND_MESSAGE_WITH_VIP_CHANNEL_PROPERTY;
 
 @Configuration
@@ -55,6 +59,18 @@ public class RMQConfigure {
     private String secretKey;
 
     private long outOfTimeSeconds;
+
+    /**
+     * Comma separated topic list for which queue-level metrics are collected.
+     * Empty (default) disables queue-level metrics completely; "*" enables them for every topic.
+     * Queue-level metrics multiply the series count by the queue number per broker,
+     * so keep this list as small as possible.
+     */
+    private String queueLevelTopics = "";
+
+    private volatile Set<String> queueLevelTopicSet = Collections.emptySet();
+
+    private volatile boolean queueLevelAllTopics = false;
 
     public boolean enableACL() {
         return this.enableACL;
@@ -142,5 +158,41 @@ public class RMQConfigure {
 
     public void setOutOfTimeSeconds(long outOfTimeSeconds) {
         this.outOfTimeSeconds = outOfTimeSeconds;
+    }
+
+    public String getQueueLevelTopics() {
+        return queueLevelTopics;
+    }
+
+    public void setQueueLevelTopics(String queueLevelTopics) {
+        this.queueLevelTopics = queueLevelTopics;
+        Set<String> topics = new HashSet<String>();
+        boolean allTopics = false;
+        if (StringUtils.isNotBlank(queueLevelTopics)) {
+            for (String topic : queueLevelTopics.split(",")) {
+                String trimmed = topic.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                if ("*".equals(trimmed)) {
+                    allTopics = true;
+                } else {
+                    topics.add(trimmed);
+                }
+            }
+        }
+        this.queueLevelTopicSet = topics;
+        this.queueLevelAllTopics = allTopics;
+        logger.info("queue-level metrics enabled for topics={}, allTopics={}", topics, allTopics);
+    }
+
+    /**
+     * @return whether queue-level metrics should be collected for the given topic
+     */
+    public boolean isQueueLevelTopic(String topic) {
+        if (queueLevelAllTopics) {
+            return true;
+        }
+        return topic != null && queueLevelTopicSet.contains(topic);
     }
 }

--- a/src/main/java/org/apache/rocketmq/exporter/model/metrics/ConsumerQueueMetric.java
+++ b/src/main/java/org/apache/rocketmq/exporter/model/metrics/ConsumerQueueMetric.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.model.metrics;
+
+/**
+ * Metric key of queue-level consumer metrics, i.e. {@link ConsumerMetric} plus the queue id.
+ */
+public class ConsumerQueueMetric {
+    private String clusterName;
+    private String brokerName;
+    private String topicName;
+    private String consumerGroupName;
+    private String queueId;
+
+    public ConsumerQueueMetric(String clusterName, String brokerName, String topicName, String consumerGroupName,
+        String queueId) {
+        this.clusterName = clusterName;
+        this.brokerName = brokerName;
+        this.topicName = topicName;
+        this.consumerGroupName = consumerGroupName;
+        this.queueId = queueId;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public void setBrokerName(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public void setTopicName(String topicName) {
+        this.topicName = topicName;
+    }
+
+    public String getConsumerGroupName() {
+        return consumerGroupName;
+    }
+
+    public void setConsumerGroupName(String consumerGroupName) {
+        this.consumerGroupName = consumerGroupName;
+    }
+
+    public String getQueueId() {
+        return queueId;
+    }
+
+    public void setQueueId(String queueId) {
+        this.queueId = queueId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ConsumerQueueMetric)) {
+            return false;
+        }
+        ConsumerQueueMetric other = (ConsumerQueueMetric) obj;
+
+        return other.clusterName.equals(clusterName) && other.brokerName.equals(brokerName)
+                && other.topicName.equals(topicName) && other.consumerGroupName.equals(consumerGroupName)
+                && other.queueId.equals(queueId);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 1;
+        hash = 37 * hash + clusterName.hashCode();
+        hash = 37 * hash + brokerName.hashCode();
+        hash = 37 * hash + topicName.hashCode();
+        hash = 37 * hash + consumerGroupName.hashCode();
+        hash = 37 * hash + queueId.hashCode();
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "clusterName: " + clusterName + "brokerName: " + brokerName
+                + "topicName: " + topicName + " ConsumeGroupName: " + consumerGroupName
+                + " queueId: " + queueId;
+    }
+}

--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -362,6 +362,7 @@ public class MetricsCollectTask {
                 // get consumer broker offset
                 try {
                     HashMap<String, Long> consumeOffsetMap = new HashMap<>();
+                    boolean queueLevelEnabled = rmqConfigure.isQueueLevelTopic(topic);
                     for (Map.Entry<MessageQueue, OffsetWrapper> consumeStatusEntry : consumeStats.getOffsetTable().entrySet()) {
                         MessageQueue q = consumeStatusEntry.getKey();
                         OffsetWrapper offset = consumeStatusEntry.getValue();
@@ -369,6 +370,14 @@ public class MetricsCollectTask {
                             consumeOffsetMap.put(q.getBrokerName(), consumeOffsetMap.get(q.getBrokerName()) + offset.getConsumerOffset());
                         } else {
                             consumeOffsetMap.put(q.getBrokerName(), offset.getConsumerOffset());
+                        }
+                        if (queueLevelEnabled) {
+                            String queueId = String.valueOf(q.getQueueId());
+                            metricsService.getCollector().addQueueConsumerOffsetMetric(clusterName,
+                                q.getBrokerName(), topic, group, queueId, offset.getConsumerOffset());
+                            metricsService.getCollector().addQueueGroupDiffMetric(clusterName,
+                                q.getBrokerName(), topic, group, queueId,
+                                offset.getBrokerOffset() - offset.getConsumerOffset());
                         }
                     }
                     for (Map.Entry<String, Long> consumeOffsetEntry : consumeOffsetMap.entrySet()) {
@@ -383,6 +392,7 @@ public class MetricsCollectTask {
                 if (MessageModel.CLUSTERING == messageModel) {
                     try {
                         HashMap<String, Long> consumerLatencyMap = new HashMap<>();
+                        boolean queueLevelEnabled = rmqConfigure.isQueueLevelTopic(topic);
                         for (Map.Entry<MessageQueue, OffsetWrapper> consumeStatusEntry : consumeStats.getOffsetTable().entrySet()) {
                             MessageQueue q = consumeStatusEntry.getKey();
                             OffsetWrapper offset = consumeStatusEntry.getValue();
@@ -403,6 +413,11 @@ public class MetricsCollectTask {
                                 consumerLatencyMap.put(q.getBrokerName(), lagTime > 0 ? lagTime : 0);
                             } else if (lagTime > consumerLatencyMap.get(q.getBrokerName())) {
                                 consumerLatencyMap.put(q.getBrokerName(), lagTime);
+                            }
+                            if (queueLevelEnabled) {
+                                metricsService.getCollector().addQueueGroupGetLatencyByStoreTimeMetric(clusterName,
+                                    q.getBrokerName(), topic, group, String.valueOf(q.getQueueId()),
+                                    lagTime > 0 ? lagTime : 0);
                             }
                         }
                         for (Map.Entry<String, Long> consumeLatencyEntry : consumerLatencyMap.entrySet()) {

--- a/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/exporter/task/MetricsCollectTask.java
@@ -731,7 +731,7 @@ public class MetricsCollectTask {
             String brokerName = clusterEntry.getValue().getBrokerName();
             String masterAddr = clusterEntry.getValue().getBrokerAddrs().get(MixAll.MASTER_ID);
             for (Map.Entry<Long, String> broker : clusterEntry.getValue().getBrokerAddrs().entrySet()) {
-                if(broker.getKey() == MixAll.MASTER_ID) {
+                if (broker.getKey() == MixAll.MASTER_ID) {
                     continue;
                 }
                 BrokerRuntimeStats slaveRuntimeStats = getBrokerRuntimeStats(broker.getValue());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,10 @@ rocketmq:
     accessKey:  # if >=4.4.0
     secretKey:  # if >=4.4.0
     outOfTimeSeconds: 60 # Cache clear time with no update
+    # Comma separated topics for which queue-level metrics (rocketmq_queue_*) are collected.
+    # Empty means disabled; "*" means all topics. Each enabled topic multiplies its series
+    # count by the number of queues per broker, so keep the list small.
+    queueLevelTopics: ""
 
 grpc:
   server:

--- a/src/test/java/org/apache/rocketmq/exporter/config/RMQConfigureQueueLevelTest.java
+++ b/src/test/java/org/apache/rocketmq/exporter/config/RMQConfigureQueueLevelTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.exporter.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RMQConfigureQueueLevelTest {
+
+    @Test
+    public void testDisabledByDefault() {
+        RMQConfigure configure = new RMQConfigure();
+        Assertions.assertFalse(configure.isQueueLevelTopic("any-topic"));
+    }
+
+    @Test
+    public void testBlankKeepsDisabled() {
+        RMQConfigure configure = new RMQConfigure();
+        configure.setQueueLevelTopics("   ");
+        Assertions.assertFalse(configure.isQueueLevelTopic("any-topic"));
+    }
+
+    @Test
+    public void testWhitelistIsExactMatchAndTrimmed() {
+        RMQConfigure configure = new RMQConfigure();
+        configure.setQueueLevelTopics(" topic-a , topic-b ,, ");
+
+        Assertions.assertTrue(configure.isQueueLevelTopic("topic-a"));
+        Assertions.assertTrue(configure.isQueueLevelTopic("topic-b"));
+        // prefix/suffix must not leak in, otherwise the series budget silently blows up
+        Assertions.assertFalse(configure.isQueueLevelTopic("topic-a-extra"));
+        Assertions.assertFalse(configure.isQueueLevelTopic("prefix-topic-a"));
+        Assertions.assertFalse(configure.isQueueLevelTopic("topic-c"));
+        Assertions.assertFalse(configure.isQueueLevelTopic(null));
+    }
+
+    @Test
+    public void testWildcardEnablesEveryTopic() {
+        RMQConfigure configure = new RMQConfigure();
+        configure.setQueueLevelTopics("topic-a,*");
+        Assertions.assertTrue(configure.isQueueLevelTopic("topic-a"));
+        Assertions.assertTrue(configure.isQueueLevelTopic("whatever"));
+    }
+
+    @Test
+    public void testResetBackToDisabled() {
+        RMQConfigure configure = new RMQConfigure();
+        configure.setQueueLevelTopics("*");
+        Assertions.assertTrue(configure.isQueueLevelTopic("topic-a"));
+
+        configure.setQueueLevelTopics("");
+        Assertions.assertFalse(configure.isQueueLevelTopic("topic-a"));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Closes #190.

All consumer-side metrics are aggregated to broker granularity today, so a single lagging queue is invisible in Prometheus — `rocketmq_group_diff` only shows that the whole group is behind, and one has to fall back to the console to see per-queue offsets. This PR exposes the queue dimension that the collector already has in hand.

`MetricsCollectTask#collectConsumerOffset` iterates `consumeStats.getOffsetTable()`, which is a `Map<MessageQueue, OffsetWrapper>`, and already computes `lagTime` one queue at a time. Both loops then fold the values into a `HashMap<brokerName, Long>` and discard `queueId`. Publishing the per-queue values therefore needs **no additional admin call** — `queryMsgByOffset` is still invoked exactly once per queue, as before.

Note that the label list for this already exists in `RMQMetricsCollector` (`GROUP_PULL_LATENCY_LABEL_NAMES`, containing `queueid`) but has never been referenced by any metric.

## Brief changelog

New metrics, all labelled `cluster, broker, topic, group, queueid`:

| metric | meaning |
| --- | --- |
| `rocketmq_queue_group_diff` | per-queue unconsumed messages (`brokerOffset - consumerOffset`) |
| `rocketmq_queue_group_get_latency_by_storetime` | per-queue consume latency in ms (reuses the already computed `lagTime`) |
| `rocketmq_queue_consumer_offset` | per-queue consumer offset |

Queue-level series multiply the consumer series count by the number of queues per broker, so they are **disabled by default** and gated by an explicit topic whitelist:

```yaml
rocketmq:
  config:
    queueLevelTopics: ""   # empty = disabled (default); "topic-a,topic-b" = whitelist; "*" = all topics
```

Changes:

* `RMQConfigure` — new `queueLevelTopics` property, parsed once in the setter into a `Set`, plus `isQueueLevelTopic(String)`.
* `ConsumerQueueMetric` (new) — metric key, i.e. `ConsumerMetric` plus `queueId`.
* `RMQMetricsCollector` — three caches reusing the existing `outOfTimeSeconds` expiry, `collectQueueGroupNums()` and three `addXxxMetric()` methods, following the existing `groupDiff` pattern.
* `MetricsCollectTask` — publishes the per-queue values inside the two existing loops, guarded by the whitelist. The broker-level aggregation is left exactly as is, so existing dashboards and alerts are unaffected.
* `application.yml` — documents the new option.

The change is purely additive: no existing line of behaviour was modified.

The second commit fixes a pre-existing checkstyle violation (`if(` missing a space, `MetricsCollectTask.java`) that currently makes `mvn clean install` fail on master regardless of this PR — without it the build command below cannot pass. Happy to split it out if you prefer.

## Verifying this change

* `mvn -B clean install -DskipITs` — **BUILD SUCCESS**, `Tests run: 5, Failures: 0, Errors: 0`
* `mvn -B clean apache-rat:check checkstyle:checkstyle` — RAT summary `Unapproved: 0, unknown: 0, approved: 39`; checkstyle clean after the second commit
* New unit test `RMQConfigureQueueLevelTest` covers the whitelist parsing: disabled by default, blank stays disabled, comma list is trimmed and matched **exactly** (`topic-a` must not enable `topic-a-extra`, otherwise the series budget silently blows up), `*` wildcard, and resetting back to disabled. The test was also verified in reverse — replacing the exact match with `startsWith` makes it fail as expected.

Note that `findbugs:findbugs` from the checklist was not run: the plugin does not support the JDK used locally (17). `spotbugs` would be the modern replacement, but that seemed out of scope for this PR.

One thing worth mentioning for the maintainers: the existing test sources are JUnit 4, while surefire 3.2.2 auto-selects the JUnit Platform provider, so `mvn test` currently reports `Tests run: 0` and no existing test actually executes. The new test is therefore written against JUnit 5 so that it really runs. Adding `junit-vintage-engine` would revive the existing ones, but again felt out of scope here.
